### PR TITLE
Handle encountering multiple manifests on the classpath when retrieving jar info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
               <exportAntProperties>true</exportAntProperties>
               <target>
                 <tstamp>
-                  <format property="build.time" pattern="yyyy-MM-dd'T'HH:mm:ss'Z'"/>
+                  <format property="build.time" pattern="yyyy-MM-dd'T'HH:mm:ssXXX"/>
                 </tstamp>
               </target>
             </configuration>
@@ -72,8 +72,8 @@
             </manifest>
             <manifestEntries>
               <!-- Add these properties to the manifest so they may be retrieved at runtime. -->
-              <Build-Time>${build.time}</Build-Time>
-              <Project-Version>${project.version}</Project-Version>
+              <Ion-Java-Build-Time>${build.time}</Ion-Java-Build-Time>
+              <Ion-Java-Project-Version>${project.version}</Ion-Java-Project-Version>
             </manifestEntries>
           </archive>
         </configuration>

--- a/src/software/amazon/ion/util/JarInfo.java
+++ b/src/software/amazon/ion/util/JarInfo.java
@@ -15,7 +15,10 @@
 package software.amazon.ion.util;
 
 import java.io.IOException;
-import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import software.amazon.ion.IonException;
@@ -28,7 +31,9 @@ import software.amazon.ion.Timestamp;
 public final class JarInfo
 {
 
-    private static final String MANIFEST_FILE = "/META-INF/MANIFEST.MF";
+    private static final String MANIFEST_FILE = "META-INF/MANIFEST.MF";
+    private static final String BUILD_TIME_ATTRIBUTE = "Ion-Java-Build-Time";
+    private static final String PROJECT_VERSION_ATTRIBUTE = "Ion-Java-Project-Version";
 
     private String ourProjectVersion;
 
@@ -43,12 +48,33 @@ public final class JarInfo
      */
     public JarInfo() throws IonException
     {
-        loadBuildProperties(getClass().getResourceAsStream(MANIFEST_FILE));
+        Enumeration<URL> manifestUrls;
+        try
+        {
+            manifestUrls = getClass().getClassLoader().getResources(MANIFEST_FILE);
+        }
+        catch (IOException e)
+        {
+            throw new IonException("Unable to load manifests.", e);
+        }
+        List<Manifest> manifests = new ArrayList<Manifest>();
+        while (manifestUrls.hasMoreElements())
+        {
+            try
+            {
+                manifests.add(new Manifest(manifestUrls.nextElement().openStream()));
+            }
+            catch (IOException e)
+            {
+                continue; // try the next manifest
+            }
+        }
+        loadBuildProperties(manifests);
     }
 
-    JarInfo(InputStream in)
+    JarInfo(List<Manifest> manifests)
     {
-        loadBuildProperties(in);
+        loadBuildProperties(manifests);
     }
 
     /**
@@ -75,42 +101,49 @@ public final class JarInfo
 
     // ========================================================================
 
-    private void loadBuildProperties(InputStream in) throws IonException
+    private void loadBuildProperties(List<Manifest> manifests) throws IonException
     {
+        boolean propertiesLoaded = false;
+        for(Manifest manifest : manifests)
+        {
+            boolean success = tryLoadBuildProperties(manifest);
+            if(success && propertiesLoaded)
+            {
+                // In the event of conflicting manifests, fail instead of risking returning incorrect version info.
+                throw new IonException("Found multiple manifests with ion-java version info on the classpath.");
+            }
+            propertiesLoaded |= success;
+        }
+        if (!propertiesLoaded)
+        {
+            throw new IonException("Unable to locate manifest with ion-java version info on the classpath.");
+        }
+    }
+
+    /*
+     * Returns true if the properties were loaded, otherwise false.
+     */
+    private boolean tryLoadBuildProperties(Manifest manifest)
+    {
+        Attributes mainAttributes = manifest.getMainAttributes();
+        String projectVersion = mainAttributes.getValue(PROJECT_VERSION_ATTRIBUTE);
+        String time = mainAttributes.getValue(BUILD_TIME_ATTRIBUTE);
+
+        if (projectVersion == null || time == null)
+        {
+            return false;
+        }
+
+        ourProjectVersion = projectVersion;
+
         try
         {
-            Manifest manifest = new Manifest();
-            if (in != null)
-            {
-                try
-                {
-                    manifest.read(in);
-                }
-                finally
-                {
-                    in.close();
-                }
-            }
-            Attributes mainAttributes = manifest.getMainAttributes();
-
-            ourProjectVersion = mainAttributes.getValue("Project-Version");
-
-            String time = mainAttributes.getValue("Build-Time");
-            if (time != null)
-            {
-                try
-                {
-                    ourBuildTime = Timestamp.valueOf(time);
-                }
-                catch (IllegalArgumentException e)
-                {
-                    // Badly formatted timestamp. Ignore it.
-                }
-            }
+            ourBuildTime = Timestamp.valueOf(time);
         }
-        catch (IOException e)
+        catch (IllegalArgumentException e)
         {
-            throw new IonException("Unable to load manifest.", e);
+            // Badly formatted timestamp. Ignore it.
         }
+        return true;
     }
 }

--- a/test/software/amazon/ion/util/JarInfoTest.java
+++ b/test/software/amazon/ion/util/JarInfoTest.java
@@ -17,25 +17,92 @@ package software.amazon.ion.util;
 import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.jar.Manifest;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import software.amazon.ion.IonException;
 import software.amazon.ion.Timestamp;
-import software.amazon.ion.util.JarInfo;
 
 public class JarInfoTest
 {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private static String getAttributes(String manifestVersion)
+    {
+        return "Manifest-Version: " + manifestVersion + "\n";
+    }
+
+    private static String getIonJavaAttributes(String buildTime, String version)
+    {
+        return getAttributes("1.0")
+            + "Ion-Java-Build-Time: " + buildTime + "\n"
+            + "Ion-Java-Project-Version: " + version + "\n";
+    }
+
+    private static Manifest getManifest(String attributes) throws IOException
+    {
+        return new Manifest(new ByteArrayInputStream(attributes.getBytes("UTF-8")));
+    }
+
     @Test
-    public void testConstruction() throws Exception
+    public void testSingleManifest() throws Exception
     {
         String expectedBuildTime = "1984T";
         String expectedVersion = "42.0";
 
-        String manifest = "Manifest-Version: 1.0\n"
-                        + "Build-Time: " + expectedBuildTime + "\n"
-                        + "Project-Version: " + expectedVersion + "\n";
-
-        JarInfo info = new JarInfo(new ByteArrayInputStream(manifest.getBytes("UTF-8")));
+        Manifest manifest = getManifest(getIonJavaAttributes(expectedBuildTime, expectedVersion));
+        JarInfo info = new JarInfo(Collections.singletonList(manifest));
 
         assertEquals(expectedVersion, info.getProjectVersion());
         assertEquals(Timestamp.valueOf(expectedBuildTime), info.getBuildTime());
     }
+
+    @Test
+    public void testMultipleManifests() throws Exception
+    {
+        String expectedBuildTime = "1984T";
+        String expectedVersion = "42.0";
+
+        List<Manifest> manifests = new ArrayList<Manifest>();
+        manifests.add(getManifest(getAttributes("1.0")));
+        manifests.add(getManifest(getIonJavaAttributes(expectedBuildTime, expectedVersion)));
+        manifests.add(getManifest(getAttributes("2.0")));
+
+        JarInfo info = new JarInfo(manifests);
+
+        assertEquals(expectedVersion, info.getProjectVersion());
+        assertEquals(Timestamp.valueOf(expectedBuildTime), info.getBuildTime());
+    }
+
+    @Test
+    public void testNoMatchingManifests() throws Exception
+    {
+        List<Manifest> manifests = new ArrayList<Manifest>();
+        manifests.add(getManifest(getAttributes("1.0")));
+        manifests.add(getManifest(getAttributes("2.0")));
+        manifests.add(getManifest(getAttributes("3.0")));
+
+        thrown.expect(IonException.class);
+        new JarInfo(manifests);
+    }
+
+    @Test
+    public void testConflictingManifests() throws Exception
+    {
+        List<Manifest> manifests = new ArrayList<Manifest>();
+        manifests.add(getManifest(getIonJavaAttributes("1984T", "42.0")));
+        manifests.add(getManifest(getAttributes("1.0")));
+        manifests.add(getManifest(getIonJavaAttributes("1985T", "43.0")));
+
+        thrown.expect(IonException.class);
+        new JarInfo(manifests);
+    }
+
 }


### PR DESCRIPTION
Created manifest keys that are more likely to be unique. Loop through all manifest files on the classpath and retrieve jar info for the one that contains both keys. If multiple manifests are found to contain both keys, fail (to avoid the risk of giving misleading or incorrect information).

Also fixes the build time format to properly include the local offset.

Works on Mac and Linux. No Windows testing yet.