### PR TITLE
Adds Support for 32-bit Floats

### DIFF
--- a/src/software/amazon/ion/impl/IonReaderBinaryRawX.java
+++ b/src/software/amazon/ion/impl/IonReaderBinaryRawX.java
@@ -1045,12 +1045,16 @@ done:   for (;;) {
             // special case, return pos zero
             return 0.0d;
         }
-        if (len != 8)
+        if (len != 4 && len != 8)
         {
-            throw new IOException("Length of float read must be 0 or 8");
+            throw new IOException("Length of float read must be 0, 4, or 8");
         }
+
         long dBits = this.readULong(len);
-        return Double.longBitsToDouble(dBits);
+
+        return len == 4
+            ? (double) Float.intBitsToFloat((int) (dBits & 0xffffffffL))
+            : Double.longBitsToDouble(dBits);
     }
     protected final long readVarULong() throws IOException
     {

--- a/src/software/amazon/ion/impl/PrivateIonBinaryWriterBuilder.java
+++ b/src/software/amazon/ion/impl/PrivateIonBinaryWriterBuilder.java
@@ -189,6 +189,35 @@ public class PrivateIonBinaryWriterBuilder
     }
 
     @Override
+    public void setIsFloatBinary32Enabled(boolean enabled) {
+        mutationCheck();
+        if (enabled)
+        {
+            myBinaryWriterBuilder.withFloatBinary32Enabled();
+        }
+        else
+        {
+            myBinaryWriterBuilder.withFloatBinary32Disabled();
+        }
+    }
+
+    @Override
+    public
+    PrivateIonBinaryWriterBuilder withFloatBinary32Enabled() {
+        PrivateIonBinaryWriterBuilder b = mutable();
+        b.setIsFloatBinary32Enabled(true);
+        return b;
+    }
+
+    @Override
+    public
+    PrivateIonBinaryWriterBuilder withFloatBinary32Disabled() {
+        PrivateIonBinaryWriterBuilder b = mutable();
+        b.setIsFloatBinary32Enabled(false);
+        return b;
+    }
+
+    @Override
     public void setImports(final SymbolTable... imports)
     {
         super.setImports(imports);

--- a/src/software/amazon/ion/impl/bin/IonManagedBinaryWriter.java
+++ b/src/software/amazon/ion/impl/bin/IonManagedBinaryWriter.java
@@ -656,7 +656,8 @@ import software.amazon.ion.impl.bin.IonRawBinaryWriter.StreamFlushMode;
             WriteValueOptimization.NONE, // optimization is not relevant for the nested raw writer
             StreamCloseMode.NO_CLOSE,
             StreamFlushMode.NO_FLUSH,
-            builder.preallocationMode
+            builder.preallocationMode,
+            builder.isFloatBinary32Enabled
         );
         this.user = new IonRawBinaryWriter(
             builder.provider,
@@ -665,7 +666,8 @@ import software.amazon.ion.impl.bin.IonRawBinaryWriter.StreamFlushMode;
             WriteValueOptimization.NONE, // optimization is not relevant for the nested raw writer
             StreamCloseMode.CLOSE,
             StreamFlushMode.FLUSH,
-            builder.preallocationMode
+            builder.preallocationMode,
+            builder.isFloatBinary32Enabled
         );
 
         this.catalog = builder.catalog;

--- a/src/software/amazon/ion/impl/bin/PrivateIonManagedBinaryWriterBuilder.java
+++ b/src/software/amazon/ion/impl/bin/PrivateIonManagedBinaryWriterBuilder.java
@@ -75,6 +75,7 @@ public final class PrivateIonManagedBinaryWriterBuilder
     /*package*/ volatile IonCatalog             catalog;
     /*package*/ volatile WriteValueOptimization optimization;
     /*package*/ volatile SymbolTable            initialSymbolTable;
+    /*package*/ volatile boolean                isFloatBinary32Enabled;
 
     private PrivateIonManagedBinaryWriterBuilder(final BlockAllocatorProvider provider)
     {
@@ -85,6 +86,7 @@ public final class PrivateIonManagedBinaryWriterBuilder
         this.preallocationMode = PreallocationMode.PREALLOCATE_2;
         this.catalog = new SimpleCatalog();
         this.optimization = WriteValueOptimization.NONE;
+        this.isFloatBinary32Enabled = false;
     }
 
     private PrivateIonManagedBinaryWriterBuilder(final PrivateIonManagedBinaryWriterBuilder other)
@@ -97,6 +99,7 @@ public final class PrivateIonManagedBinaryWriterBuilder
         this.catalog            = other.catalog;
         this.optimization       = other.optimization;
         this.initialSymbolTable = other.initialSymbolTable;
+        this.isFloatBinary32Enabled = other.isFloatBinary32Enabled;
     }
 
     public PrivateIonManagedBinaryWriterBuilder copy()
@@ -185,6 +188,16 @@ public final class PrivateIonManagedBinaryWriterBuilder
     public PrivateIonManagedBinaryWriterBuilder withStreamCopyOptimization(boolean optimized)
     {
         this.optimization = optimized ? WriteValueOptimization.COPY_OPTIMIZED : WriteValueOptimization.NONE;
+        return this;
+    }
+
+    public PrivateIonManagedBinaryWriterBuilder withFloatBinary32Enabled() {
+        isFloatBinary32Enabled = true;
+        return this;
+    }
+
+    public PrivateIonManagedBinaryWriterBuilder withFloatBinary32Disabled() {
+        isFloatBinary32Enabled = false;
         return this;
     }
 

--- a/src/software/amazon/ion/system/IonBinaryWriterBuilder.java
+++ b/src/software/amazon/ion/system/IonBinaryWriterBuilder.java
@@ -173,6 +173,63 @@ public abstract class IonBinaryWriterBuilder
     IonBinaryWriterBuilder withInitialSymbolTable(SymbolTable symtab);
 
 
+    /**
+     * Enables or disables writing Binary32 (4-byte, single precision,
+     * IEEE-754) values for floats when there would be no loss in precision.
+     * By default Binary32 support is disabled to ensure the broadest
+     * compatibility with existing Ion implementations. Historically,
+     * implementations were only able to read Binary64 values.
+     * <p>
+     * When enabled, floats are evaluated for a possible loss of data at single
+     * precision. If the value can be represented in single precision without
+     * data loss, it is written as a 4-byte, Binary32 value. Floats which cannot
+     * be represented as single-precision values are  written as 8-byte,
+     * Binary64 values (this is the legacy behavior for all  floats, regardless
+     * of value).
+     *
+     * @param enabled {@code true} to enable writing 4-byte floats,
+     * {@code false} to always write 8-byte floats.
+     *
+     * @see IonBinaryWriterBuilder#withFloatBinary32Enabled
+     * @see IonBinaryWriterBuilder#withFloatBinary32Disabled
+     */
+    public abstract void setIsFloatBinary32Enabled(boolean enabled);
+
+    /**
+     * Enables writing Binary32 (4-byte, single precision,  IEEE-754) values
+     * for floats when there would be no loss in precision. By default Binary32
+     * support is disabled to ensure the broadest compatibility with existing
+     * Ion implementations. Historically, implementations were only able to read
+     * Binary64 values.
+     * <p>
+     * When enabled, floats are evaluated for a possible loss of data at single
+     * precision. If the value can be represented in single precision without
+     * data loss, it is written as a 4-byte, Binary32 value. Floats which
+     * cannot be represented as single-precision values are written as 8-byte,
+     * Binary64 values (this is the legacy behavior for all floats, regardless
+     * of value).
+     *
+     * @see IonBinaryWriterBuilder#setIsFloatBinary32Enabled(boolean)
+     * @see IonBinaryWriterBuilder#withFloatBinary32Disabled
+     */
+    public abstract IonBinaryWriterBuilder withFloatBinary32Enabled();
+
+    /**
+     * Disables writing Binary32 (4-byte, single precision, IEEE-754) values for
+     * floats. This is the default behavior.
+     * <p>
+     * When disabled, floats are always written as 8-byte, Binary64 values
+     * regardless of value. This is the legacy behavior for all Ion binary
+     * writers and ensures the boarded compatibility with other Ion consumers.
+     *
+     * @param enabled {@code true} to enable writing 4-byte floats,
+     * {@code false} to always write 8-byte floats.
+     *
+     * @see IonBinaryWriterBuilder#setIsFloatBinary32Enabled(boolean)
+     * @see IonBinaryWriterBuilder#withFloatBinary32Enabled
+     */
+    public abstract IonBinaryWriterBuilder withFloatBinary32Disabled();
+
     //=========================================================================
 
 

--- a/test/software/amazon/ion/BinaryTest.java
+++ b/test/software/amazon/ion/BinaryTest.java
@@ -173,6 +173,28 @@ public class BinaryTest extends IonTestCase
     }
 
     @Test
+    public void testBinReadFloat05()
+    {
+        // 1e0
+        IonValue val = ion("44 3f 80 00 00");
+
+        assertTrue(val instanceof IonFloat);
+        assertTrue(1.0 == ((IonFloat) val).doubleValue());
+    }
+
+    @Test
+    public void testBinReadFloat06()
+    {
+        // ≈ -991221.0227
+        IonValue val = ion("44 C9 71 FF 50");
+
+        assertTrue(val instanceof IonFloat);
+        // since 32-bit values are upcast to 64-bit values, check
+        // the double representation
+        assertDoubleBits(val, 0xc12e3fea00000000L);
+    }
+
+    @Test
     public void testBinWriteFloat01()
     {
         IonFloat fval = system().newNullFloat();

--- a/test/software/amazon/ion/impl/bin/IonManagedBinaryWriterTest.java
+++ b/test/software/amazon/ion/impl/bin/IonManagedBinaryWriterTest.java
@@ -104,6 +104,12 @@ public class IonManagedBinaryWriterTest extends IonRawBinaryWriterTest
         }
     }
 
+    @Override
+    public int ivmLength() {
+        return 4;
+    }
+
+
     @Inject("importedSymbolResolverMode")
     public static final ImportedSymbolResolverMode[] RESOLVER_DIMENSIONS = ImportedSymbolResolverMode.values();
 
@@ -131,6 +137,7 @@ public class IonManagedBinaryWriterTest extends IonRawBinaryWriterTest
             .create(AllocatorMode.POOLED)
             .withImports(importedSymbolResolverMode, symbolTables)
             .withPreallocationMode(preallocationMode)
+            .withFloatBinary32Enabled()
             .newWriter(out);
 
         final SymbolTable locals = writer.getSymbolTable();

--- a/test/software/amazon/ion/system/IonBinaryWriterBuilderTest.java
+++ b/test/software/amazon/ion/system/IonBinaryWriterBuilderTest.java
@@ -146,6 +146,65 @@ public class IonBinaryWriterBuilderTest
 
     //-------------------------------------------------------------------------
 
+    @Test
+    public void testSetIsFloatBinary32Enabled() throws IOException
+    {
+        IonSystem system = IonSystemBuilder.standard().build();
+
+        IonBinaryWriterBuilder b = IonBinaryWriterBuilder.standard();
+        b.setIsFloatBinary32Enabled(true);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonWriter writer = b.build(out);
+        writer.writeFloat(1.0);
+        writer.close();
+        assertEquals(9, out.size());
+        assertEquals(system.newFloat(1.0), system.singleValue(out.toByteArray()));
+
+        b.setIsFloatBinary32Enabled(false);
+
+        out = new ByteArrayOutputStream();
+        writer = b.build(out);
+        writer.writeFloat(1.0);
+        writer.close();
+        assertEquals(13, out.size());
+        assertEquals(system.newFloat(1.0), system.singleValue(out.toByteArray()));
+    }
+
+    @Test
+    public void testWithFloatBinary32Enabled() throws IOException
+    {
+        IonSystem system = IonSystemBuilder.standard().build();
+
+        IonBinaryWriterBuilder b = IonBinaryWriterBuilder.standard()
+            .withFloatBinary32Enabled();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonWriter writer = b.build(out);
+        writer.writeFloat(1.0);
+        writer.close();
+        assertEquals(9, out.size());
+        assertEquals(system.newFloat(1.0), system.singleValue(out.toByteArray()));
+    }
+
+    @Test
+    public void testWithFloatBinary32Disabled() throws IOException
+    {
+        IonSystem system = IonSystemBuilder.standard().build();
+
+        IonBinaryWriterBuilder b = IonBinaryWriterBuilder.standard()
+            .withFloatBinary32Disabled();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonWriter writer = b.build(out);
+        writer.writeFloat(1.0);
+        writer.close();
+        assertEquals(13, out.size());
+        assertEquals(system.newFloat(1.0), system.singleValue(out.toByteArray()));
+    }
+
+    //-------------------------------------------------------------------------
+
 
     @Test
     public void testSymtabValueFactory()


### PR DESCRIPTION
IonReaderBinaryRawX has learned to read the length of the float
type.

IonRawBinaryWriter has learned how to write 32-bit float values
when there will be no loss in precision.

Ref: http://amznlabs.github.io/ion-docs/float.html