### PR TITLE
Added getIntegerType API to IonReader and IonInt.

### DIFF
--- a/src/software/amazon/ion/IntegerSize.java
+++ b/src/software/amazon/ion/IntegerSize.java
@@ -1,0 +1,31 @@
+// Copyright (c) 2016 Amazon.com, Inc.  All rights reserved.
+
+package software.amazon.ion;
+
+/**
+ * Indicates the smallest-possible Java type of an Ion {@code int} value.
+ */
+public enum IntegerSize
+{
+    /**
+     * Fits in the Java {@code int} primitive (four bytes).
+     * The value can be retrieved through methods like {@link IonReader#intValue()}
+     * or {@link IonInt#intValue()} without data loss.
+     */
+    INT,
+
+    /**
+     * Fits in the Java {@code int} primitive (eight bytes).
+     * The value can be retrieved through methods like {@link IonReader#longValue()}
+     * or {@link IonInt#longValue()} without data loss.
+     */
+    LONG,
+
+    /**
+     * Larger than eight bytes. This value can be retrieved through methods like
+     * {@link IonReader#bigIntegerValue()} or {@link IonInt#bigIntegerValue()}
+     * without data loss.
+     */
+    BIG_INTEGER,
+
+}

--- a/src/software/amazon/ion/IonInt.java
+++ b/src/software/amazon/ion/IonInt.java
@@ -56,6 +56,15 @@ public interface IonInt
     public BigInteger bigIntegerValue();
 
     /**
+     * Gets an {@link IntegerSize} representing the smallest-possible
+     * Java type of the underlying content, or {@code null} if this is
+     * {@code null.int}.
+     *
+     * @see IonReader#getIntegerSize()
+     */
+    public IntegerSize getIntegerSize();
+
+    /**
      * Sets the content of this value.
      */
     public void setValue(int value);

--- a/src/software/amazon/ion/IonReader.java
+++ b/src/software/amazon/ion/IonReader.java
@@ -172,6 +172,18 @@ public interface IonReader
     public IonType getType();
 
     /**
+     * Returns an {@link IntegerSize} representing the smallest-possible
+     * Java type of the Ion {@code int} at the current value.
+     *
+     * If the current value is {@code null.int} or is not an Ion
+     * {@code int}, or if there is no current value, {@code null} will
+     * be returned.
+     *
+     * @see IonInt#getIntegerSize()
+     */
+    public IntegerSize getIntegerSize();
+
+    /**
      * Return the annotations of the current value as an array of strings.
      *
      * @return the (ordered) annotations on the current value, or an empty

--- a/src/software/amazon/ion/impl/IonReaderTextRawTokensX.java
+++ b/src/software/amazon/ion/impl/IonReaderTextRawTokensX.java
@@ -2727,6 +2727,12 @@ final class IonReaderTextRawTokensX
             {
                 return IonTokenConstsX.isBinaryDigit(c);
             }
+
+            @Override
+            char normalizeDigit(char c)
+            {
+                return c; // no normalization required
+            }
         },
 
         DECIMAL
@@ -2739,6 +2745,12 @@ final class IonReaderTextRawTokensX
             boolean isValidDigit(int c)
             {
                 return IonTokenConstsX.isDigit(c);
+            }
+
+            @Override
+            char normalizeDigit(char c)
+            {
+                return c; // no normalization required
             }
         },
 
@@ -2753,10 +2765,17 @@ final class IonReaderTextRawTokensX
             {
                 return IonTokenConstsX.isHexDigit(c);
             }
+
+            @Override
+            char normalizeDigit(char c)
+            {
+                return Character.toLowerCase(c);
+            }
         };
 
         abstract boolean isPrefix(int c);
         abstract boolean isValidDigit(int c);
+        abstract char normalizeDigit(char c);
 
         void assertPrefix(int c)
         {
@@ -2781,7 +2800,7 @@ final class IonReaderTextRawTokensX
                 case START:
                     if (radix.isValidDigit(c))
                     {
-                        buffer.append((char) c);
+                        buffer.append(radix.normalizeDigit((char) c));
                         state = NumericState.DIGIT;
                     }
                     else
@@ -2792,7 +2811,7 @@ final class IonReaderTextRawTokensX
                 case DIGIT:
                     if (radix.isValidDigit(c))
                     {
-                        buffer.append((char) c);
+                        buffer.append(radix.normalizeDigit((char) c));
                         state = NumericState.DIGIT;
                     }
                     else if (c == '_')
@@ -2807,7 +2826,7 @@ final class IonReaderTextRawTokensX
                 case UNDERSCORE:
                     if (radix.isValidDigit(c))
                     {
-                        buffer.append((char) c);
+                        buffer.append(radix.normalizeDigit((char) c));
                         state = NumericState.DIGIT;
                     }
                     else

--- a/src/software/amazon/ion/impl/IonReaderTreeSystem.java
+++ b/src/software/amazon/ion/impl/IonReaderTreeSystem.java
@@ -23,6 +23,7 @@ import java.math.BigInteger;
 import java.util.Date;
 import java.util.Iterator;
 import software.amazon.ion.Decimal;
+import software.amazon.ion.IntegerSize;
 import software.amazon.ion.IonBool;
 import software.amazon.ion.IonContainer;
 import software.amazon.ion.IonDatagram;
@@ -532,6 +533,18 @@ class IonReaderTreeSystem
     // system readers don't skip any symbol tables
     public SymbolTable pop_passed_symbol_table()
     {
+        return null;
+    }
+
+
+    @Override
+    public IntegerSize getIntegerSize()
+    {
+        if(_curr instanceof IonInt)
+        {
+            return ((IonInt)_curr).getIntegerSize();
+
+        }
         return null;
     }
 }

--- a/src/software/amazon/ion/impl/PrivateScalarConversions.java
+++ b/src/software/amazon/ion/impl/PrivateScalarConversions.java
@@ -18,6 +18,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Date;
 import software.amazon.ion.Decimal;
+import software.amazon.ion.IntegerSize;
 import software.amazon.ion.IonException;
 import software.amazon.ion.IonType;
 import software.amazon.ion.Timestamp;
@@ -58,6 +59,20 @@ public class PrivateScalarConversions
                                                    | idx_to_bit_mask(datetime_types)
                                                    | idx_to_bit_mask(boolean_value)
                                                    | idx_to_bit_mask(string_value);
+    }
+
+    public static IntegerSize getIntegerSize(int authoritative_type) {
+        switch (authoritative_type)
+        {
+            case AS_TYPE.int_value:
+                return IntegerSize.INT;
+            case AS_TYPE.long_value:
+                return IntegerSize.LONG;
+            case AS_TYPE.bigInteger_value:
+                return IntegerSize.BIG_INTEGER;
+            default:
+                return null;
+        }
     }
 
     public static String getValueTypeName(int value_type) {
@@ -413,6 +428,7 @@ public class PrivateScalarConversions
                                + getValueTypeName(value_type);
                 throw new IllegalStateException(message);
             }
+            _authoritative_type_idx = value_type;
         }
         public final void setValueToNull(IonType t) {
             _is_null = true;

--- a/src/software/amazon/ion/impl/SymbolTableReader.java
+++ b/src/software/amazon/ion/impl/SymbolTableReader.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
 import software.amazon.ion.Decimal;
+import software.amazon.ion.IntegerSize;
 import software.amazon.ion.IonException;
 import software.amazon.ion.IonReader;
 import software.amazon.ion.IonType;
@@ -1352,5 +1353,14 @@ final class SymbolTableReader
     public void close() throws IOException
     {
         _current_state = S_EOF;
+    }
+
+    public IntegerSize getIntegerSize()
+    {
+        if (stateType(_current_state) != IonType.INT)
+        {
+            return null;
+        }
+        return IntegerSize.INT; // all of SymbolTable's integers are type int
     }
 }

--- a/src/software/amazon/ion/impl/bin/AbstractIonWriter.java
+++ b/src/software/amazon/ion/impl/bin/AbstractIonWriter.java
@@ -113,8 +113,23 @@ import software.amazon.ion.impl.PrivateUtils;
                 writeBool(booleanValue);
                 break;
             case INT:
-                final BigInteger bigIntegerValue = reader.bigIntegerValue();
-                writeInt(bigIntegerValue);
+                switch (reader.getIntegerSize())
+                {
+                    case INT:
+                        final int intValue = reader.intValue();
+                        writeInt(intValue);
+                        break;
+                    case LONG:
+                        final long longValue = reader.longValue();
+                        writeInt(longValue);
+                        break;
+                    case BIG_INTEGER:
+                        final BigInteger bigIntegerValue = reader.bigIntegerValue();
+                        writeInt(bigIntegerValue);
+                        break;
+                    default:
+                        throw new IllegalStateException();
+                }
                 break;
             case FLOAT:
                 final double doubleValue = reader.doubleValue();

--- a/src/software/amazon/ion/impl/lite/IonValueLite.java
+++ b/src/software/amazon/ion/impl/lite/IonValueLite.java
@@ -74,6 +74,36 @@ abstract class IonValueLite
     private   static final int ELEMENT_MASK       = 0xff;
     protected static final int ELEMENT_SHIFT      = 8; // low 8 bits is flag, upper 24 (or 48 is element id)
 
+    /**
+     * Used by subclasses to retrieve metadata set by
+     * {@link #_setMetadata(int, int, int)}.
+     * @param mask the location of the metadata to retrieve.
+     * @param shift the number of bits to right-shift the metadata so that
+     *              it starts at bit index 0.
+     * @return the metadata from _flags at the given mask.
+     */
+    protected final int _getMetadata(int mask, int shift) {
+        return (_flags & mask) >>> shift;
+    }
+
+    /**
+     * May be used by subclasses to reuse _flag bits for purposes specific
+     * to that subclass. It is important that only flag bits not currently
+     * used by that subclass are chosen; otherwise important data may be
+     * overwritten. NOTE: only the lower 8 bits may be used, because the
+     * upper 24 are reserved for the element ID.
+     * @param metadata the metadata to set.
+     * @param mask the location at which to set the metadata. Must be within
+     *             the lower 8 bits.
+     * @param shift the number of bits to left-shift the metadata so that
+     *              it starts at the index of the mask's LSB.
+     */
+    protected final void _setMetadata(int metadata, int mask, int shift) {
+        assert(mask <= ELEMENT_MASK); // don't overwrite the element ID
+        _flags &= ~mask;
+        _flags |= ((metadata << shift) & mask);
+    }
+
     protected final void _elementid(int elementid) {
         _flags &= ELEMENT_MASK;
         _flags |= (elementid << ELEMENT_SHIFT);

--- a/test/AllTests.java
+++ b/test/AllTests.java
@@ -76,6 +76,7 @@ import software.amazon.ion.streaming.GoodIonStreamingTest;
 import software.amazon.ion.streaming.InputStreamReaderTest;
 import software.amazon.ion.streaming.MiscStreamingTest;
 import software.amazon.ion.streaming.ReaderDomCopyTest;
+import software.amazon.ion.streaming.ReaderIntegerSizeTest;
 import software.amazon.ion.streaming.ReaderSkippingTest;
 import software.amazon.ion.streaming.ReaderTest;
 import software.amazon.ion.streaming.RoundTripStreamingTest;
@@ -173,6 +174,7 @@ import software.amazon.ion.util.TextTest;
     RoundTripStreamingTest.class,
     ReaderDomCopyTest.class,
     ReaderSkippingTest.class,
+    ReaderIntegerSizeTest.class,
 
     IonSystemTest.class,
     ValueFactorySequenceTest.class,

--- a/test/software/amazon/ion/streaming/ReaderIntegerSizeTest.java
+++ b/test/software/amazon/ion/streaming/ReaderIntegerSizeTest.java
@@ -1,0 +1,161 @@
+// Copyright (c) 2016 Amazon.com, Inc.  All rights reserved.
+
+package software.amazon.ion.streaming;
+
+import java.math.BigInteger;
+import org.junit.Test;
+import software.amazon.ion.IntegerSize;
+import software.amazon.ion.ReaderMaker;
+import software.amazon.ion.junit.Injected.Inject;
+
+public class ReaderIntegerSizeTest
+    extends ReaderTestCase
+{
+
+    private enum IntRadix {
+        DECIMAL
+        {
+            @Override
+            String getString(BigInteger integer)
+            {
+                return integer.toString();
+            }
+        },
+        HEX
+        {
+            @Override
+            String getString(BigInteger integer)
+            {
+                return injectRadixPrefix("0x", integer.toString(16));
+            }
+        },
+        HEX_UPPER
+        {
+            @Override
+            String getString(BigInteger integer)
+            {
+                return injectRadixPrefix("0x", integer.toString(16).toUpperCase());
+            }
+        },
+        BINARY
+        {
+            @Override
+            String getString(BigInteger integer)
+            {
+                return injectRadixPrefix("0b", integer.toString(2));
+            }
+        };
+
+        abstract String getString(BigInteger integer);
+
+        private static String injectRadixPrefix(String radixPrefix, String value)
+        {
+            if(value.charAt(0) == '-')
+            {
+                value = "-" + radixPrefix + value.replaceFirst("-", "");
+            }
+            else
+            {
+                value = radixPrefix + value;
+            }
+            return value;
+        }
+    }
+
+    @Inject("readerMaker")
+    public static final ReaderMaker[] READER_MAKERS = ReaderMaker.values();
+
+    @Inject("radix")
+    public static final IntRadix[] RADIXES = IntRadix.values();
+
+    public IntRadix radix;
+
+    public void setRadix(IntRadix value)
+    {
+        radix = value;
+    }
+
+    @Test
+    public void testGetIntegerSizeNull()
+    {
+        read(  "null "
+             + "true false "
+             + "null.int "
+             + "42.1 -421e-1 "
+             + "123d4 "
+             + "2016-08T "
+             + "\"bar\" "
+             + "foo "
+             + "{{ abcd }} "
+             + "{{ \"abcd\" }} "
+             + "{} "
+             + "[] "
+             + "() "
+            );
+        while (in.next() != null)
+        {
+            assertNull(in.getIntegerSize());
+        }
+    }
+
+    @Test
+    public void testGetIntegerSizePositiveLongBoundary()
+    {
+        long boundary = Long.MAX_VALUE;
+        testGetIntegerSizeLongBoundary(boundary, loadBoundaries(boundary, radix));
+    }
+
+    @Test
+    public void testGetIntegerSizeNegativeLongBoundary()
+    {
+        long boundary = Long.MIN_VALUE;
+        testGetIntegerSizeLongBoundary(boundary, loadBoundaries(boundary, radix));
+    }
+
+    @Test
+    public void testGetIntegerSizePositiveIntBoundary()
+    {
+        int boundary = Integer.MAX_VALUE;
+        testGetIntegerSizeIntBoundary(boundary, loadBoundaries(boundary, radix).longValue());
+    }
+
+    @Test
+    public void testGetIntegerSizeNegativeIntBoundary()
+    {
+        int boundary = Integer.MIN_VALUE;
+        testGetIntegerSizeIntBoundary(boundary, loadBoundaries(boundary, radix).longValue());
+    }
+
+    private void testGetIntegerSizeIntBoundary(int boundaryValue, long pastBoundary)
+    {
+        in.next();
+        assertEquals(IntegerSize.INT, in.getIntegerSize());
+        assertEquals(boundaryValue, in.intValue());
+        assertEquals(IntegerSize.INT, in.getIntegerSize()); // assert nothing changes until next()
+        in.next();
+        assertEquals(IntegerSize.LONG, in.getIntegerSize());
+        assertEquals(pastBoundary, in.longValue());
+        assertEquals(IntegerSize.LONG, in.getIntegerSize());
+    }
+
+    private void testGetIntegerSizeLongBoundary(long boundaryValue, BigInteger pastBoundary)
+    {
+        in.next();
+        assertEquals(IntegerSize.LONG, in.getIntegerSize());
+        assertEquals(boundaryValue, in.longValue());
+        assertEquals(IntegerSize.LONG, in.getIntegerSize());
+        in.next();
+        assertEquals(IntegerSize.BIG_INTEGER, in.getIntegerSize());
+        assertEquals(pastBoundary, in.bigIntegerValue());
+        assertEquals(IntegerSize.BIG_INTEGER, in.getIntegerSize());
+    }
+
+    private BigInteger loadBoundaries(long boundaryValue, IntRadix intRadix)
+    {
+        BigInteger boundary = BigInteger.valueOf(boundaryValue);
+        BigInteger pastBoundary = (boundaryValue < 0) ? boundary.subtract(BigInteger.ONE) : boundary.add(BigInteger.ONE);
+        String ionText = intRadix.getString(boundary) + " " + intRadix.getString(pastBoundary);
+        read(ionText);
+        return pastBoundary;
+    }
+}


### PR DESCRIPTION
The changes in AbstractIonWriter show how this can be useful. Whereas previously Ion ints were all resurrected as BigIntegers for safety, they can now be resurrected into the smallest possible integer data type.

See #76 