### PR TITLE
Remove `apps` package from OSGi export list.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,9 +109,11 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Private-Package>software.amazon.ion.impl.*</Private-Package>
-            <Export-Package>!software.amazon.ion.impl.*,software.amazon.ion.*</Export-Package>
-            <Import-Package>!software.amazon.ion.*</Import-Package>
+            <Export-Package>
+              !software.amazon.ion.apps.*,
+              !software.amazon.ion.impl.*,
+              software.amazon.ion.*,
+            </Export-Package>
             <!-- This can be used to retrieve the compiled JarInfo. -->
             <Main-Class>software.amazon.ion.impl.PrivateCommandLine</Main-Class>
             <!-- Add these properties to the manifest so they may be retrieved at runtime. -->
@@ -167,7 +169,7 @@
   </reporting>
 
   <profiles>
-    <profile> 
+    <profile>
       <id>release</id>
       <build>
         <plugins>


### PR DESCRIPTION
It is not intended to be an API for customer use.

Removed the Import-Package instruction, because the documentation says it should be rarely used.

Relevant entries in `MANIFEST.MF` before the change:
```
Export-Package: software.amazon.ion;uses:="software.amazon.ion.facet,s
 oftware.amazon.ion.system";version="1.0.2",software.amazon.ion.apps;u
 ses:="software.amazon.ion";version="1.0.2",software.amazon.ion.facet;
 version="1.0.2",software.amazon.ion.system;uses:="software.amazon.ion
 ";version="1.0.2",software.amazon.ion.util;uses:="software.amazon.ion
 ";version="1.0.2"
```

After the change:
```
Export-Package: software.amazon.ion;uses:="software.amazon.ion.facet,s
 oftware.amazon.ion.system";version="1.0.2",software.amazon.ion.facet;
 version="1.0.2",software.amazon.ion.system;uses:="software.amazon.ion
 ";version="1.0.2",software.amazon.ion.util;uses:="software.amazon.ion
 ";version="1.0.2"
Import-Package: software.amazon.ion.facet
```

Note the omission of `s.a.i.apps` from the second line.